### PR TITLE
Cortex Engineer Lore Proposal

### DIFF
--- a/cortex_lore/CorEngineer.md
+++ b/cortex_lore/CorEngineer.md
@@ -1,0 +1,7 @@
+With the conception of the Field Command Unit and its, at the time, theoretical ability to create an army virtually anywhere at any time, it's limitations quickly became clear to Cortex Commanders. A singular unit was still only able to construct so much at once.
+
+This in mind, the Commanders of Cortex decided to create a supplemental and versatile workforce to back them up in the field, allowing for rapid, even exponential base expansion and army growth.
+
+Enter the Cortex Engineer Corp. With unit types spread across land, sea, and air, and each unit equipped individually with an RTG to provide supplemental energy. Cortex Engineers could create even distant expansions to a Commander's base and outposts, sometimes entirely independently.
+
+A notable early example where this benefit came into play in battle would be when Commander Hercules used this to great effect in the Serendipity System. By securing his position, expanding his metal extraction operations, and reclaiming wreckage right behind his advancing armies, he took rapid advantage of ground taken from Armada Commander Marcella, allowing his armies to grow at an ever increasing rate.


### PR DESCRIPTION
This is my sample proposal for the engineers lore item. Given that they all serve the same purpose, and are effectively the same unit with differing stats and skins, I figured a single lore piece that discusses all of the engineer types as a collective whole may be better suited for this situation. If desired, a distinction between Tier 1 and Tier 2 engineers can be worked in as two separate lore items for each faction.

A similar draft is in the works for Armada Engineers, and can easily be reworked to fit into the suggested Tech Tier Distinction change.